### PR TITLE
Allow synchronous snapshots on RO replicas

### DIFF
--- a/pgconfigure
+++ b/pgconfigure
@@ -1,7 +1,7 @@
 #!/bin/sh
 rm -rf postgres
 mkdir postgres
-curl -s -v --retry 5 -L https://github.com/postgres/postgres/archive/refs/tags/REL_15_2.tar.gz | tar xz --strip-components 1 -C postgres
+curl -s --retry 5 -L https://github.com/postgres/postgres/archive/refs/tags/REL_15_2.tar.gz | tar xz --strip-components 1 -C postgres
 
 if [ "$OS" = "Windows_NT" ]; then
   (cd postgres/src/tools/msvc/ && perl mkvcbuild.pl)

--- a/src/postgres_scanner.cpp
+++ b/src/postgres_scanner.cpp
@@ -87,14 +87,12 @@ static void PostgresGetSnapshot(PostgresVersion version, const PostgresBindData 
 		return;
 	}
 
+	// As of PostgreSQL 10.0 (right after 9.6), synchronous snapshots
+	// are allowed on replicas. (https://www.postgresql.org/docs/release/10.0/)
 	result =
-	    con.TryQuery("SELECT pg_is_in_recovery(), pg_export_snapshot(), (select count(*) from pg_stat_wal_receiver)");
+	    con.TryQuery("SELECT pg_export_snapshot()");
 	if (result) {
-		auto in_recovery = result->GetBool(0, 0) || result->GetInt64(0, 2) > 0;
-		gstate.snapshot = "";
-		if (!in_recovery) {
-			gstate.snapshot = result->GetString(0, 1);
-		}
+		gstate.snapshot = result->GetString(0, 1);
 		return;
 	}
 }

--- a/src/postgres_scanner.cpp
+++ b/src/postgres_scanner.cpp
@@ -92,7 +92,7 @@ static void PostgresGetSnapshot(PostgresVersion version, const PostgresBindData 
 	result =
 	    con.TryQuery("SELECT pg_export_snapshot()");
 	if (result) {
-		gstate.snapshot = result->GetString(0, 1);
+		gstate.snapshot = result->GetString(0, 0);
 		return;
 	}
 }


### PR DESCRIPTION
Remake of allow-sync-snapshot-on-replicas that skips the versioning changes and only focuses on enabling sync exports.