### PR TITLE
Merge DuckDB's v1.1.3 build commit

### DIFF
--- a/.github/workflows/InternalIssuesCreateMirror.yml
+++ b/.github/workflows/InternalIssuesCreateMirror.yml
@@ -1,4 +1,4 @@
-name: Create Internal issue when the "High Priority" label is applied
+name: Create or Label Mirror Issue
 on:
   issues:
     types:
@@ -6,19 +6,17 @@ on:
 
 env:
   GH_TOKEN: ${{ secrets.DUCKDBLABS_BOT_TOKEN }}
-  # an event triggering this workflow is either an issue or a pull request,
-  # hence only one of the numbers will be filled in the TITLE_PREFIX
   TITLE_PREFIX: "[postgres_scanner/#${{ github.event.issue.number }}]"
   PUBLIC_ISSUE_TITLE: ${{ github.event.issue.title }}
 
 jobs:
   create_or_label_issue:
-    if: github.event.label.name == 'High Priority'
+    if: github.event.label.name == 'reproduced' || github.event.label.name == 'under review'
     runs-on: ubuntu-latest
     steps:
       - name: Get mirror issue number
         run: |
-          gh issue list --repo duckdblabs/duckdb-internal --search "${TITLE_PREFIX}" --json title,number --jq ".[] | select(.title | startswith(\"$TITLE_PREFIX\")).number" > mirror_issue_number.txt
+          gh issue list --repo duckdblabs/duckdb-internal --search "${TITLE_PREFIX}" --json title,number --state all --jq ".[] | select(.title | startswith(\"$TITLE_PREFIX\")).number" > mirror_issue_number.txt
           echo "MIRROR_ISSUE_NUMBER=$(cat mirror_issue_number.txt)" >> $GITHUB_ENV
 
       - name: Print whether mirror issue exists
@@ -31,6 +29,7 @@ jobs:
 
       - name: Create or label issue
         run: |
+          export LABEL="postgres"
           if [ "$MIRROR_ISSUE_NUMBER" == "" ]; then
-            gh issue create --repo duckdblabs/duckdb-internal --label "extension" --label "High Priority" --title "$TITLE_PREFIX - $PUBLIC_ISSUE_TITLE" --body "See https://github.com/duckdb/postgres_scanner/issues/${{ github.event.issue.number }}"
+            gh issue create --repo duckdblabs/duckdb-internal --label "$LABEL" --title "$TITLE_PREFIX - $PUBLIC_ISSUE_TITLE" --body "See https://github.com/duckdb/postgres_scanner/issues/${{ github.event.issue.number }}"
           fi

--- a/.github/workflows/InternalIssuesUpdateMirror.yml
+++ b/.github/workflows/InternalIssuesUpdateMirror.yml
@@ -1,0 +1,48 @@
+name: Update Mirror Issue
+on:
+  issues:
+    types:
+      - closed
+      - reopened
+
+env:
+  GH_TOKEN: ${{ secrets.DUCKDBLABS_BOT_TOKEN }}
+  TITLE_PREFIX: "[postgres_scanner/#${{ github.event.issue.number }}]"
+
+jobs:
+  update_mirror_issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get mirror issue number
+        run: |
+          gh issue list --repo duckdblabs/duckdb-internal --search "${TITLE_PREFIX}" --json title,number --state all --jq ".[] | select(.title | startswith(\"$TITLE_PREFIX\")).number" > mirror_issue_number.txt
+          echo "MIRROR_ISSUE_NUMBER=$(cat mirror_issue_number.txt)" >> $GITHUB_ENV
+
+      - name: Print whether mirror issue exists
+        run: |
+          if [ "$MIRROR_ISSUE_NUMBER" == "" ]; then
+            echo "Mirror issue with title prefix '$TITLE_PREFIX' does not exist yet"
+          else
+            echo "Mirror issue with title prefix '$TITLE_PREFIX' exists with number $MIRROR_ISSUE_NUMBER"
+          fi
+
+      - name: Add comment with status to mirror issue
+        run: |
+          if [ "$MIRROR_ISSUE_NUMBER" != "" ]; then
+            gh issue comment --repo duckdblabs/duckdb-internal $MIRROR_ISSUE_NUMBER --body "The issue has been ${{ github.event.action }} (https://github.com/duckdb/postgres_scanner/issues/${{ github.event.issue.number }})."
+          fi
+
+      - name: Add closed label to mirror issue
+        if: github.event.action == 'closed'
+        run: |
+          if [ "$MIRROR_ISSUE_NUMBER" != "" ]; then
+            gh issue edit --repo duckdblabs/duckdb-internal $MIRROR_ISSUE_NUMBER --add-label "public closed" --remove-label "public reopened"
+          fi
+
+      - name: Reopen mirror issue and add reopened label
+        if: github.event.action == 'reopened'
+        run: |
+          if [ "$MIRROR_ISSUE_NUMBER" != "" ]; then
+            gh issue reopen --repo duckdblabs/duckdb-internal $MIRROR_ISSUE_NUMBER
+            gh issue edit --repo duckdblabs/duckdb-internal $MIRROR_ISSUE_NUMBER --add-label "public reopened" --remove-label "public closed"
+          fi

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -27,6 +27,7 @@ jobs:
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_triplet }}
       GEN: Ninja
       VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
     - name: Install required ubuntu packages

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -113,7 +113,7 @@ jobs:
         source ./create-postgres-tables.sh
         make test_release
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: ${{matrix.arch}}-extensions
         path: |

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -14,19 +14,19 @@ concurrency:
 jobs:
   duckdb-stable-build:
     name: Build extension binaries
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.0.0
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
-      duckdb_version: v1.0.0
+      duckdb_version: main
       extension_name: postgres_scanner
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools'
 
   duckdb-stable-deploy:
     name: Deploy extension binaries
     needs: duckdb-stable-build
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@v1.0.0
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@main
     secrets: inherit
     with:
-      duckdb_version: v1.0.0
+      duckdb_version: main
       extension_name: postgres_scanner
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools'
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -14,19 +14,19 @@ concurrency:
 jobs:
   duckdb-stable-build:
     name: Build extension binaries
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.0.0
     with:
-      duckdb_version: main
+      duckdb_version: v1.0.0
       extension_name: postgres_scanner
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools'
 
   duckdb-stable-deploy:
     name: Deploy extension binaries
     needs: duckdb-stable-build
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@main
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@v1.0.0
     secrets: inherit
     with:
-      duckdb_version: main
+      duckdb_version: v1.0.0
       extension_name: postgres_scanner
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools'
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}

--- a/Makefile
+++ b/Makefile
@@ -72,9 +72,9 @@ release:
 
 test: test_release
 test_release: release
-	./build/release/$(TEST_PATH) "$(PROJ_DIR)test/*"
+	./build/release/$(TEST_PATH) --test-dir "$(PROJ_DIR)" "test/*"
 test_debug: debug
-	./build/debug/$(TEST_PATH) "$(PROJ_DIR)test/*"
+	./build/debug/$(TEST_PATH) --test-dir "$(PROJ_DIR)" "test/*"
 
 format:
 	cp duckdb/.clang-format .

--- a/src/include/postgres_binary_writer.hpp
+++ b/src/include/postgres_binary_writer.hpp
@@ -200,6 +200,13 @@ public:
 		}
 	}
 
+	void WriteRawBlob(string_t value) {
+		auto str_size = value.GetSize();
+		auto str_data = value.GetData();
+		WriteRawInteger<int32_t>(NumericCast<int32_t>(str_size));
+		stream.WriteData(const_data_ptr_cast(str_data), str_size);
+	}
+
 	void WriteVarchar(string_t value) {
 		auto str_size = value.GetSize();
 		auto str_data = value.GetData();
@@ -219,11 +226,10 @@ public:
 					new_str += str_data[i];
 				}
 			}
-			WriteVarchar(new_str);
+			WriteRawBlob(new_str);
 			return;
 		}
-		WriteRawInteger<int32_t>(NumericCast<int32_t>(str_size));
-		stream.WriteData(const_data_ptr_cast(str_data), str_size);
+		WriteRawBlob(value);
 	}
 
 	void WriteArray(Vector &col, idx_t r, const vector<uint32_t> &dimensions, idx_t depth, uint32_t count) {
@@ -336,10 +342,14 @@ public:
 			WriteUUID(data);
 			break;
 		}
-		case LogicalTypeId::BLOB:
 		case LogicalTypeId::VARCHAR: {
 			auto data = FlatVector::GetData<string_t>(col)[r];
 			WriteVarchar(data);
+			break;
+		}
+		case LogicalTypeId::BLOB: {
+			auto data = FlatVector::GetData<string_t>(col)[r];
+			WriteRawBlob(data);
 			break;
 		}
 		case LogicalTypeId::ENUM: {

--- a/src/include/postgres_connection.hpp
+++ b/src/include/postgres_connection.hpp
@@ -29,10 +29,6 @@ struct OwnedPostgresConnection {
 	PGconn *connection;
 };
 
-struct PostgresCopyState {
-	PostgresCopyFormat format = PostgresCopyFormat::AUTO;
-};
-
 class PostgresConnection {
 public:
 	explicit PostgresConnection(shared_ptr<OwnedPostgresConnection> connection = nullptr);

--- a/src/include/postgres_utils.hpp
+++ b/src/include/postgres_utils.hpp
@@ -46,6 +46,14 @@ struct PostgresType {
 
 enum class PostgresCopyFormat { AUTO = 0, BINARY = 1, TEXT = 2 };
 
+struct PostgresCopyState {
+	PostgresCopyFormat format = PostgresCopyFormat::AUTO;
+	bool has_null_byte_replacement = false;
+	string null_byte_replacement;
+
+	void Initialize(ClientContext &context);
+};
+
 class PostgresUtils {
 public:
 	static PGconn *PGConnect(const string &dsn);

--- a/src/include/storage/postgres_catalog.hpp
+++ b/src/include/storage/postgres_catalog.hpp
@@ -20,7 +20,7 @@ class PostgresSchemaEntry;
 
 class PostgresCatalog : public Catalog {
 public:
-	explicit PostgresCatalog(AttachedDatabase &db_p, const string &path, AccessMode access_mode);
+	explicit PostgresCatalog(AttachedDatabase &db_p, const string &path, AccessMode access_mode, string schema_to_load);
 	~PostgresCatalog();
 
 	string path;
@@ -93,6 +93,7 @@ private:
 	PostgresVersion version;
 	PostgresSchemaSet schemas;
 	PostgresConnectionPool connection_pool;
+	string default_schema;
 };
 
 } // namespace duckdb

--- a/src/include/storage/postgres_delete.hpp
+++ b/src/include/storage/postgres_delete.hpp
@@ -44,7 +44,7 @@ public:
 	}
 
 	string GetName() const override;
-	string ParamsToString() const override;
+	InsertionOrderPreservingMap<string> ParamsToString() const override;
 };
 
 } // namespace duckdb

--- a/src/include/storage/postgres_index_set.hpp
+++ b/src/include/storage/postgres_index_set.hpp
@@ -20,7 +20,7 @@ public:
 	PostgresIndexSet(PostgresSchemaEntry &schema, unique_ptr<PostgresResultSlice> index_result = nullptr);
 
 public:
-	static string GetInitializeQuery();
+	static string GetInitializeQuery(const string &schema = string());
 
 	optional_ptr<CatalogEntry> CreateIndex(ClientContext &context, CreateIndexInfo &info, TableCatalogEntry &table);
 

--- a/src/include/storage/postgres_insert.hpp
+++ b/src/include/storage/postgres_insert.hpp
@@ -53,7 +53,7 @@ public:
 	}
 
 	string GetName() const override;
-	string ParamsToString() const override;
+	InsertionOrderPreservingMap<string> ParamsToString() const override;
 };
 
 } // namespace duckdb

--- a/src/include/storage/postgres_schema_set.hpp
+++ b/src/include/storage/postgres_schema_set.hpp
@@ -16,15 +16,19 @@ struct CreateSchemaInfo;
 
 class PostgresSchemaSet : public PostgresCatalogSet {
 public:
-	explicit PostgresSchemaSet(Catalog &catalog);
+	explicit PostgresSchemaSet(Catalog &catalog, string schema_to_load);
 
 public:
 	optional_ptr<CatalogEntry> CreateSchema(ClientContext &context, CreateSchemaInfo &info);
 
-	static string GetInitializeQuery();
+	static string GetInitializeQuery(const string &schema = string());
 
 protected:
 	void LoadEntries(ClientContext &context) override;
+
+protected:
+	//! Schema to load - if empty loads all schemas (default behavior)
+	string schema_to_load;
 };
 
 } // namespace duckdb

--- a/src/include/storage/postgres_type_set.hpp
+++ b/src/include/storage/postgres_type_set.hpp
@@ -25,8 +25,8 @@ public:
 public:
 	optional_ptr<CatalogEntry> CreateType(ClientContext &context, CreateTypeInfo &info);
 
-	static string GetInitializeEnumsQuery(PostgresVersion version);
-	static string GetInitializeCompositesQuery();
+	static string GetInitializeEnumsQuery(PostgresVersion version, const string &schema = string());
+	static string GetInitializeCompositesQuery(const string &schema = string());
 
 protected:
 	bool HasInternalDependencies() const override {

--- a/src/include/storage/postgres_update.hpp
+++ b/src/include/storage/postgres_update.hpp
@@ -46,7 +46,7 @@ public:
 	}
 
 	string GetName() const override;
-	string ParamsToString() const override;
+	InsertionOrderPreservingMap<string> ParamsToString() const override;
 };
 
 } // namespace duckdb

--- a/src/postgres_copy_to.cpp
+++ b/src/postgres_copy_to.cpp
@@ -282,6 +282,8 @@ void PostgresConnection::CopyChunk(ClientContext &context, PostgresCopyState &st
 				varchar_types.push_back(LogicalType::VARCHAR);
 			}
 			varchar_chunk.Initialize(Allocator::DefaultAllocator(), varchar_types);
+		} else {
+			varchar_chunk.Reset();
 		}
 		D_ASSERT(chunk.ColumnCount() == varchar_chunk.ColumnCount());
 		// for text format cast to varchar first

--- a/src/postgres_copy_to.cpp
+++ b/src/postgres_copy_to.cpp
@@ -5,6 +5,24 @@
 
 namespace duckdb {
 
+void PostgresCopyState::Initialize(ClientContext &context) {
+	Value replacement_value;
+	if (!context.TryGetCurrentSetting("pg_null_byte_replacement", replacement_value)) {
+		return;
+	}
+	if (replacement_value.IsNull()) {
+		return;
+	}
+	auto replacement_str = StringValue::Get(replacement_value);
+	for (const auto c : replacement_str) {
+		if (c == '\0') {
+			throw InternalException("NULL byte replacement string cannot contain NULL values");
+		}
+	}
+	has_null_byte_replacement = true;
+	null_byte_replacement = std::move(replacement_str);
+}
+
 void PostgresConnection::BeginCopyTo(ClientContext &context, PostgresCopyState &state, PostgresCopyFormat format,
                                      const string &schema_name, const string &table_name,
                                      const vector<string> &column_names) {
@@ -24,6 +42,7 @@ void PostgresConnection::BeginCopyTo(ClientContext &context, PostgresCopyState &
 		query += ") ";
 	}
 	query += "FROM STDIN (FORMAT ";
+	state.Initialize(context);
 	state.format = format;
 	switch (state.format) {
 	case PostgresCopyFormat::BINARY:
@@ -43,7 +62,7 @@ void PostgresConnection::BeginCopyTo(ClientContext &context, PostgresCopyState &
 	}
 	if (state.format == PostgresCopyFormat::BINARY) {
 		// binary copy requires a header
-		PostgresBinaryWriter writer;
+		PostgresBinaryWriter writer(state);
 		writer.WriteHeader();
 		CopyData(writer);
 	}
@@ -70,12 +89,12 @@ void PostgresConnection::CopyData(PostgresTextWriter &writer) {
 void PostgresConnection::FinishCopyTo(PostgresCopyState &state) {
 	if (state.format == PostgresCopyFormat::BINARY) {
 		// binary copy requires a footer
-		PostgresBinaryWriter writer;
+		PostgresBinaryWriter writer(state);
 		writer.WriteFooter();
 		CopyData(writer);
 	} else if (state.format == PostgresCopyFormat::TEXT) {
 		// text copy requires a footer
-		PostgresTextWriter writer;
+		PostgresTextWriter writer(state);
 		writer.WriteFooter();
 		CopyData(writer);
 	}
@@ -263,7 +282,7 @@ void PostgresConnection::CopyChunk(ClientContext &context, PostgresCopyState &st
 	chunk.Flatten();
 
 	if (state.format == PostgresCopyFormat::BINARY) {
-		PostgresBinaryWriter writer;
+		PostgresBinaryWriter writer(state);
 		for (idx_t r = 0; r < chunk.size(); r++) {
 			writer.BeginRow(chunk.ColumnCount());
 			for (idx_t c = 0; c < chunk.ColumnCount(); c++) {
@@ -290,7 +309,7 @@ void PostgresConnection::CopyChunk(ClientContext &context, PostgresCopyState &st
 		}
 		varchar_chunk.SetCardinality(chunk.size());
 
-		PostgresTextWriter writer;
+		PostgresTextWriter writer(state);
 		for (idx_t r = 0; r < chunk.size(); r++) {
 			for (idx_t c = 0; c < chunk.ColumnCount(); c++) {
 				if (c > 0) {

--- a/src/postgres_execute.cpp
+++ b/src/postgres_execute.cpp
@@ -45,7 +45,7 @@ static void PGExecuteFunction(ClientContext &context, TableFunctionInput &data_p
 		return;
 	}
 	auto &transaction = Transaction::Get(context, data.pg_catalog).Cast<PostgresTransaction>();
-	transaction.ExecuteQueries(data.query);
+	transaction.Query(data.query);
 	data.finished = true;
 }
 

--- a/src/postgres_extension.cpp
+++ b/src/postgres_extension.cpp
@@ -48,7 +48,7 @@ public:
 class PostgresExtensionCallback : public ExtensionCallback {
 public:
 	void OnConnectionOpened(ClientContext &context) override {
-		context.registered_state.insert(make_pair("postgres_extension", make_shared_ptr<PostgresExtensionState>()));
+		context.registered_state->Insert("postgres_extension", make_shared_ptr<PostgresExtensionState>());
 	}
 };
 
@@ -174,7 +174,7 @@ static void LoadInternal(DatabaseInstance &db) {
 
 	config.extension_callbacks.push_back(make_uniq<PostgresExtensionCallback>());
 	for (auto &connection : ConnectionManager::Get(db).GetConnectionList()) {
-		connection->registered_state.insert(make_pair("postgres_extension", make_shared_ptr<PostgresExtensionState>()));
+		connection->registered_state->Insert("postgres_extension", make_shared_ptr<PostgresExtensionState>());
 	}
 }
 

--- a/src/postgres_query.cpp
+++ b/src/postgres_query.cpp
@@ -92,5 +92,6 @@ PostgresQueryFunction::PostgresQueryFunction()
 	init_local = scan_function.init_local;
 	function = scan_function.function;
 	projection_pushdown = true;
+	global_initialization = TableFunctionInitialization::INITIALIZE_ON_SCHEDULE;
 }
 } // namespace duckdb

--- a/src/postgres_scanner.cpp
+++ b/src/postgres_scanner.cpp
@@ -231,14 +231,14 @@ static void PostgresInitInternal(ClientContext &context, const PostgresBindData 
 		D_ASSERT(!bind_data->sql.empty());
 		lstate.sql = StringUtil::Format(
 		    R"(
-	COPY (SELECT %s FROM (%s) AS __unnamed_subquery %s) TO STDOUT (FORMAT binary);
+	COPY (SELECT %s FROM (%s) AS __unnamed_subquery %s) TO STDOUT (FORMAT "binary");
 	)",
 		    col_names, bind_data->sql, filter);
 
 	} else {
 		lstate.sql = StringUtil::Format(
 		    R"(
-	COPY (SELECT %s FROM %s.%s %s) TO STDOUT (FORMAT binary);
+	COPY (SELECT %s FROM %s.%s %s) TO STDOUT (FORMAT "binary");
 	)",
 		    col_names, KeywordHelper::WriteQuoted(bind_data->schema_name, '"'),
 		    KeywordHelper::WriteQuoted(bind_data->table_name, '"'), filter);

--- a/src/postgres_scanner.cpp
+++ b/src/postgres_scanner.cpp
@@ -502,7 +502,6 @@ double PostgresScanProgress(ClientContext &context, const FunctionData *bind_dat
 
 	lock_guard<mutex> parallel_lock(gstate.lock);
 	double progress = 100 * double(gstate.page_idx) / double(bind_data.pages_approx);
-	;
 	return MinValue<double>(100, progress);
 }
 

--- a/src/postgres_scanner.cpp
+++ b/src/postgres_scanner.cpp
@@ -525,6 +525,7 @@ PostgresScanFunction::PostgresScanFunction()
 	cardinality = PostgresScanCardinality;
 	table_scan_progress = PostgresScanProgress;
 	projection_pushdown = true;
+	global_initialization = TableFunctionInitialization::INITIALIZE_ON_SCHEDULE;
 }
 
 PostgresScanFunctionFilterPushdown::PostgresScanFunctionFilterPushdown()
@@ -538,6 +539,7 @@ PostgresScanFunctionFilterPushdown::PostgresScanFunctionFilterPushdown()
 	table_scan_progress = PostgresScanProgress;
 	projection_pushdown = true;
 	filter_pushdown = true;
+	global_initialization = TableFunctionInitialization::INITIALIZE_ON_SCHEDULE;
 }
 
 } // namespace duckdb

--- a/src/postgres_storage.cpp
+++ b/src/postgres_storage.cpp
@@ -58,12 +58,15 @@ static unique_ptr<Catalog> PostgresAttach(StorageExtensionInfo *storage_info, Cl
 	string connection_string = info.path;
 
 	string secret_name;
+	string schema_to_load;
 	for (auto &entry : info.options) {
 		auto lower_name = StringUtil::Lower(entry.first);
 		if (lower_name == "type" || lower_name == "read_only") {
 			// already handled
 		} else if (lower_name == "secret") {
 			secret_name = entry.second.ToString();
+		} else if (lower_name == "schema") {
+			schema_to_load = entry.second.ToString();
 		} else {
 			throw BinderException("Unrecognized option for Postgres attach: %s", entry.first);
 		}
@@ -93,7 +96,7 @@ static unique_ptr<Catalog> PostgresAttach(StorageExtensionInfo *storage_info, Cl
 		// secret not found and one was explicitly provided - throw an error
 		throw BinderException("Secret with name \"%s\" not found", secret_name);
 	}
-	return make_uniq<PostgresCatalog>(db, connection_string, access_mode);
+	return make_uniq<PostgresCatalog>(db, connection_string, access_mode, std::move(schema_to_load));
 }
 
 static unique_ptr<TransactionManager> PostgresCreateTransactionManager(StorageExtensionInfo *storage_info,

--- a/src/postgres_utils.cpp
+++ b/src/postgres_utils.cpp
@@ -253,6 +253,7 @@ LogicalType PostgresUtils::ToPostgresType(const LogicalType &input) {
 	case LogicalTypeId::UINTEGER:
 		return LogicalType::BIGINT;
 	case LogicalTypeId::UBIGINT:
+          return LogicalType::DECIMAL(20, 0);
 	case LogicalTypeId::HUGEINT:
 		return LogicalType::DOUBLE;
 	default:

--- a/src/postgres_utils.cpp
+++ b/src/postgres_utils.cpp
@@ -253,7 +253,7 @@ LogicalType PostgresUtils::ToPostgresType(const LogicalType &input) {
 	case LogicalTypeId::UINTEGER:
 		return LogicalType::BIGINT;
 	case LogicalTypeId::UBIGINT:
-          return LogicalType::DECIMAL(20, 0);
+		return LogicalType::DECIMAL(20, 0);
 	case LogicalTypeId::HUGEINT:
 		return LogicalType::DOUBLE;
 	default:

--- a/src/storage/postgres_delete.cpp
+++ b/src/storage/postgres_delete.cpp
@@ -110,8 +110,10 @@ string PostgresDelete::GetName() const {
 	return "PG_DELETE";
 }
 
-string PostgresDelete::ParamsToString() const {
-	return table.name;
+InsertionOrderPreservingMap<string> PostgresDelete::ParamsToString() const {
+	InsertionOrderPreservingMap<string> result;
+	result["Table Name"] = table.name;
+	return result;
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/postgres_insert.cpp
+++ b/src/storage/postgres_insert.cpp
@@ -144,8 +144,10 @@ string PostgresInsert::GetName() const {
 	return table ? "PG_INSERT" : "PG_CREATE_TABLE_AS";
 }
 
-string PostgresInsert::ParamsToString() const {
-	return table ? table->name : info->Base().table;
+InsertionOrderPreservingMap<string> PostgresInsert::ParamsToString() const {
+	InsertionOrderPreservingMap<string> result;
+	result["Table Name"] = table ? table->name : info->Base().table;
+	return result;
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/postgres_table_set.cpp
+++ b/src/storage/postgres_table_set.cpp
@@ -255,7 +255,7 @@ string PostgresColumnsToSQL(const ColumnList &columns, const vector<unique_ptr<C
 		if (column.Oid() > 0) {
 			ss << ", ";
 		}
-		ss << KeywordHelper::WriteOptionallyQuoted(column.Name()) << " ";
+		ss << KeywordHelper::WriteQuoted(column.Name(), '"') << " ";
 		ss << PostgresUtils::TypeToString(column.Type());
 		bool not_null = not_null_columns.find(column.Logical()) != not_null_columns.end();
 		bool is_single_key_pk = pk_columns.find(column.Logical()) != pk_columns.end();

--- a/src/storage/postgres_update.cpp
+++ b/src/storage/postgres_update.cpp
@@ -171,8 +171,10 @@ string PostgresUpdate::GetName() const {
 	return "PG_UPDATE";
 }
 
-string PostgresUpdate::ParamsToString() const {
-	return table.name;
+InsertionOrderPreservingMap<string> PostgresUpdate::ParamsToString() const {
+	InsertionOrderPreservingMap<string> result;
+	result["Table Name"] = table.name;
+	return result;
 }
 
 //===--------------------------------------------------------------------===//

--- a/test/other.sql
+++ b/test/other.sql
@@ -104,7 +104,7 @@ CREATE TABLE my_table (
 insert into my_table values (42, 'something', 'something else');
 
 
-	CREATE SCHEMA some_schema;
+CREATE SCHEMA some_schema;
 
 create type some_schema.some_enum as enum('one', 'two');
 

--- a/test/sql/scanner/aws-rds.test
+++ b/test/sql/scanner/aws-rds.test
@@ -2,6 +2,8 @@
 # description: Read over AWS RDS
 # group: [scanner]
 
+mode skip
+
 require postgres_scanner
 
 require-env POSTGRES_TEST_DATABASE_AVAILABLE

--- a/test/sql/storage/attach_copy_from_database.test
+++ b/test/sql/storage/attach_copy_from_database.test
@@ -29,6 +29,18 @@ CREATE TABLE ${table_name} AS FROM public.${table_name}
 endloop
 
 statement ok
+USE memory
+
+statement ok
+DETACH s1
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s1 (TYPE POSTGRES, SCHEMA 'copy_schema')
+
+statement ok
+USE s1.copy_schema
+
+statement ok
 create table big_tbl as from range(100000) t(id)
 
 statement ok
@@ -46,7 +58,8 @@ COPY FROM DATABASE s1 TO new_db
 foreach table_name pg_numtypes pg_bytetypes pg_datetypes big_tbl my_view
 
 query I
-FROM new_db.${table_name} EXCEPT FROM ${table_name}
+SELECT COUNT(*) FROM (FROM new_db.copy_schema.${table_name} EXCEPT FROM ${table_name})
 ----
+0
 
 endloop

--- a/test/sql/storage/attach_copy_from_database.test
+++ b/test/sql/storage/attach_copy_from_database.test
@@ -1,0 +1,52 @@
+# name: test/sql/storage/attach_copy_from_database.test
+# description: Test copy from database
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s1 (TYPE POSTGRES)
+
+statement ok
+DROP SCHEMA IF EXISTS s1.copy_schema CASCADE
+
+statement ok
+CREATE SCHEMA s1.copy_schema
+
+statement ok
+USE s1.copy_schema
+
+foreach table_name pg_numtypes pg_bytetypes pg_datetypes
+
+statement ok
+CREATE TABLE ${table_name} AS FROM public.${table_name}
+
+endloop
+
+statement ok
+create table big_tbl as from range(100000) t(id)
+
+statement ok
+create index i_index on big_tbl(id)
+
+statement ok
+create view my_view as select min(id) from copy_schema.big_tbl
+
+statement ok
+ATTACH '__TEST_DIR__/copy_database.db' AS new_db;
+
+statement ok
+COPY FROM DATABASE s1 TO new_db
+
+foreach table_name pg_numtypes pg_bytetypes pg_datetypes big_tbl my_view
+
+query I
+FROM new_db.${table_name} EXCEPT FROM ${table_name}
+----
+
+endloop

--- a/test/sql/storage/attach_create_uppercase_names.test
+++ b/test/sql/storage/attach_create_uppercase_names.test
@@ -1,0 +1,24 @@
+# name: test/sql/storage/attach_create_uppercase_names.test
+# description: Test creating tables with uppercase column names
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok
+USE s
+
+statement ok
+CREATE OR REPLACE TABLE MyTable AS SELECT 42 MyColumn, 84 MySecondColumn
+
+query II
+SELECT MyColumn, MySecondColumn FROM MyTable
+----
+42	84

--- a/test/sql/storage/attach_null_byte.test
+++ b/test/sql/storage/attach_null_byte.test
@@ -1,0 +1,65 @@
+# name: test/sql/storage/attach_null_byte.test
+# description: Test inserting null byte values through ATTACH
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s1 (TYPE POSTGRES)
+
+statement ok
+USE s1
+
+foreach pg_binary true false
+
+statement ok
+SET pg_use_binary_copy=${pg_binary}
+
+statement ok
+CREATE OR REPLACE TABLE nullbyte_tbl(s VARCHAR);
+
+statement error
+INSERT INTO nullbyte_tbl VALUES (chr(0))
+----
+Postgres does not support NULL-bytes in VARCHAR values
+
+statement ok
+SET pg_null_byte_replacement=''
+
+statement ok
+INSERT INTO nullbyte_tbl VALUES (chr(0)), ('FF' || chr(0) || 'FF');
+
+query I
+SELECT * FROM nullbyte_tbl
+----
+(empty)
+FFFF
+
+statement ok
+SET pg_null_byte_replacement='NULLBYTE'
+
+statement ok
+INSERT INTO nullbyte_tbl VALUES (chr(0)), ('FF' || chr(0) || 'FF');
+
+query I
+SELECT * FROM nullbyte_tbl
+----
+(empty)
+FFFF
+NULLBYTE
+FFNULLBYTEFF
+
+statement ok
+RESET pg_null_byte_replacement
+
+endloop
+
+statement error
+SET pg_null_byte_replacement=chr(0)
+----
+NULL byte replacement string cannot contain NULL values

--- a/test/sql/storage/attach_schema_param.test
+++ b/test/sql/storage/attach_schema_param.test
@@ -1,0 +1,36 @@
+# name: test/sql/storage/attach_schema_param.test
+# description: Test attaching only a specific schema
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES, SCHEMA 'some_schema')
+
+query I
+SELECT * FROM s.some_schema.some_table
+----
+two
+
+query I
+SELECT * FROM s.some_table
+----
+two
+
+statement error
+SELECT * FROM s.public.my_table
+----
+does not exist
+
+statement ok
+USE s;
+
+query I
+SELECT * FROM some_table
+----
+two

--- a/test/sql/storage/attach_temporary_table.test
+++ b/test/sql/storage/attach_temporary_table.test
@@ -2,6 +2,8 @@
 # description: Test attaching and querying a Postgres temporary table
 # group: [storage]
 
+mode skip
+
 require postgres_scanner
 
 require-env POSTGRES_TEST_DATABASE_AVAILABLE

--- a/test/sql/storage/attach_types.test
+++ b/test/sql/storage/attach_types.test
@@ -36,7 +36,7 @@ NULL	NULL	NULL	NULL
 # test all types
 statement ok
 CREATE TABLE all_types_tbl AS SELECT *
-EXCLUDE (float, double, ubigint, hugeint, uhugeint, nested_int_array, struct, struct_of_arrays, array_of_structs, map, "union", fixed_int_array, fixed_varchar_array, fixed_nested_int_array, fixed_nested_varchar_array, fixed_struct_array, struct_of_fixed_array, fixed_array_of_int_list, list_of_fixed_int_array)
+EXCLUDE (float, double, ubigint, hugeint, uhugeint, nested_int_array, struct, struct_of_arrays, array_of_structs, map, "union", fixed_int_array, fixed_varchar_array, fixed_nested_int_array, fixed_nested_varchar_array, fixed_struct_array, struct_of_fixed_array, fixed_array_of_int_list, list_of_fixed_int_array, varint)
 REPLACE(
 	CASE WHEN int IS NOT NULL THEN '2000-01-01' ELSE NULL END AS date,
 	CASE WHEN int IS NOT NULL THEN '2000-01-01 01:02:03' ELSE NULL END AS timestamp,

--- a/test/sql/storage/attach_ubigint.test
+++ b/test/sql/storage/attach_ubigint.test
@@ -1,0 +1,27 @@
+# name: test/sql/storage/attach_ubigint.test
+# description: Test inserting/querying UBIGINT
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok
+USE s;
+
+statement ok
+CREATE OR REPLACE TABLE ubigints(u UBIGINT);
+
+statement ok
+INSERT INTO ubigints VALUES (1394265502879208448);
+
+query I
+SELECT u::VARCHAR FROM ubigints
+----
+1394265502879208448

--- a/test/sql/storage/attach_varchar_list_nulls.test
+++ b/test/sql/storage/attach_varchar_list_nulls.test
@@ -1,0 +1,32 @@
+# name: test/sql/storage/attach_varchar_list_nulls.test
+# description: Test inserting/querying VARCHAR lists with NULL values
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok
+CREATE OR REPLACE TABLE s.varchar_list_big(i BIGINT, v VARCHAR[]);
+
+statement ok
+CREATE TABLE tbl AS SELECT CASE WHEN i<1000 THEN NULL ELSE i END i, case when i<1000 then null else [i] end v FROM range(4000) t(i);
+
+query IIII
+select min(len(v)), max(len(v)), sum(len(v)), count(*) from tbl;
+----
+1	1	3000	4000
+
+statement ok
+INSERT INTo s.varchar_list_big FROM tbl
+
+query IIII
+select min(len(v)), max(len(v)), sum(len(v)), count(*) from s.varchar_list_big;
+----
+1	1	3000	4000

--- a/test/sql/storage/postgres_execute_transaction.test
+++ b/test/sql/storage/postgres_execute_transaction.test
@@ -1,0 +1,54 @@
+# name: test/sql/storage/postgres_execute_transaction.test
+# description: Test interactions of postgres_execute and transactions
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok
+CREATE OR REPLACE TABLE s.postgres_execute_attempt(i INTEGER);
+
+statement ok
+BEGIN
+
+query I
+CALL postgres_query('s', 'SELECT 42')
+----
+42
+
+statement ok
+CALL postgres_execute('s', 'INSERT INTO postgres_execute_attempt VALUES (42)')
+
+statement ok
+ROLLBACK
+
+query I
+FROM s.postgres_execute_attempt
+----
+
+statement ok
+BEGIN
+
+query I
+CALL postgres_query('s', 'SELECT 42')
+----
+42
+
+statement ok
+CALL postgres_execute('s', 'INSERT INTO postgres_execute_attempt VALUES (42); INSERT INTO postgres_execute_attempt VALUES (84)')
+
+statement ok
+COMMIT
+
+query I
+FROM s.postgres_execute_attempt
+----
+42
+84


### PR DESCRIPTION
I'm going to be applying the diff below to our builds to make sure that we're using this repo instead of upstream for the postgres_scanner builds. duckdb 1.1.3 builds on top of 03eaed75f0ec5500609b7a97aa05468493b229d1, but main is currently behind that. This causes build errors due to interfaces that have changed from our upstream root to 03eaed75f0ec5500609b7a97aa05468493b229d1. 

This PR is a merge commit between main and 03eaed75f0ec5500609b7a97aa05468493b229d1


```
diff --git a/.github/config/out_of_tree_extensions.cmake b/.github/config/out_of_tree_extensions.cmake
index 8a5436b368..37fb78d72e 100644
--- a/.github/config/out_of_tree_extensions.cmake
+++ b/.github/config/out_of_tree_extensions.cmake
@@ -89,11 +89,12 @@ duckdb_extension_load(inet
 ################# POSTGRES_SCANNER
 # Note: tests for postgres_scanner are currently not run. All of them need a postgres server running. One test
 #       uses a remote rds server but that's not something we want to run here.
+# Note (ABX): This commit is "Allow synchronous snapshots on RO replicas (#2)" made on Jun 2, 2025
 if (NOT MINGW)
     duckdb_extension_load(postgres_scanner
             DONT_LINK
-            GIT_URL https://github.com/duckdb/postgres_scanner
-            GIT_TAG 03eaed75f0ec5500609b7a97aa05468493b229d1
+            GIT_URL https://github.com/abnormal-security/postgres_scanner
+            GIT_TAG <the sha on main when I merge this>
             )
 endif()
```